### PR TITLE
Remove "sort_order" from Lists API doc

### DIFF
--- a/doc/lists_api.md
+++ b/doc/lists_api.md
@@ -40,7 +40,6 @@ Should result in this response:
       "name": "New Voters",
       "slug": "newvoters",
       "author_id": 1,
-      "sort_order": "oldest_first",
       "count": 5
     },
     {
@@ -48,7 +47,6 @@ Should result in this response:
       "name": "Famous Minnesotans",
       "slug": "minnesotans",
       "author_id": 15236,
-      "sort_order": "oldest_first",
       "count": 21
     },
     {
@@ -56,7 +54,6 @@ Should result in this response:
       "name": "Donors",
       "slug": "donors",
       "author_id": 15236,
-      "sort_order": "oldest_first",
       "count": 101
     }
   ]
@@ -128,8 +125,6 @@ Creates an empty list with the given attributes.
   * `name` - the name of the list
   * `slug` - a unique identifier for the list
   * `author_id` - the author of the list
-  * `sort_order` - the order in which the list is sorted for retrieval
-    * Options: `oldest_first`, `newest_first`, `priority_level`, `street_address`, `last_name`
 
 ### Example
 
@@ -146,8 +141,7 @@ With this post body:
   "list": {
     "name": "My List",
     "slug": "mylist",
-    "author_id": 17736,
-    "sort_order": "oldest_first"
+    "author_id": 17736
   }
 }
 ```
@@ -160,8 +154,7 @@ Should result in this response:
     "id": 12,
     "name": "My List",
     "slug": "mylist",
-    "author_id": 17736,
-    "sort_order": "oldest_first",
+    "author_id": 17736
     "count": 0
   }
 }

--- a/doc/people_api.md
+++ b/doc/people_api.md
@@ -1035,7 +1035,7 @@ GET /api/v1/people/search
 * `with_mobile` - only people with mobile phone numbers
 * `custom_values` - match custom field values. It takes a nested format, e.g. `{"custom_values": {"my_field_slug": "abcd"}}`. In the query string this parameter would have to be encoded as `custom_values%5Bmy_field_slug%5D=abcd`.
 * `page` - page number (default: 1)
-* `per_page` - number of results to show per page (default: 10, max: 100)
+* `per_page` - number of results to show per page (default: 10, max: 1000)
 
 ### Example
 

--- a/doc/people_api.md
+++ b/doc/people_api.md
@@ -1035,7 +1035,7 @@ GET /api/v1/people/search
 * `with_mobile` - only people with mobile phone numbers
 * `custom_values` - match custom field values. It takes a nested format, e.g. `{"custom_values": {"my_field_slug": "abcd"}}`. In the query string this parameter would have to be encoded as `custom_values%5Bmy_field_slug%5D=abcd`.
 * `page` - page number (default: 1)
-* `per_page` - number of results to show per page (default: 10, max: 1000)
+* `per_page` - number of results to show per page (default: 10, max: 100)
 
 ### Example
 


### PR DESCRIPTION
"sort_order" does not appear to exist anymore - I can't seem to set it via the API, nor is it returned in any List API requests.