### PR TITLE
Remove tagging hooks

### DIFF
--- a/doc/webhooks_api.md
+++ b/doc/webhooks_api.md
@@ -9,8 +9,6 @@ Use the webhooks API to manage callback requests that you wish to receive on the
 | Person changed            | `person_changed`      |
 | Person contacted          | `person_contacted`    |
 | Person destroyed          | `person_destroyed`    |
-| Person tagged             | `person_tagged`       |
-| Person untagged           | `person_untagged`     |
 | Person merged             | `person_merged`       |
 | People destroyed in batch | `people_destroyed`    |
 | Donation succeeded        | `donation_succeeded`  |


### PR DESCRIPTION
Neither of these webhooks are available through the API, meanwhile tagging or untagging a person fires a person_changed webhook.

cc: @aq1018 @3dna/web-services 