### PR TITLE
Update lists/people endpoints

### DIFF
--- a/doc/lists_api.md
+++ b/doc/lists_api.md
@@ -39,7 +39,6 @@ Should result in this response:
       "name": "New Voters",
       "slug": "newvoters",
       "author_id": 1,
-      "sort_order": "oldest_first",
       "count": 5
     },
     {
@@ -47,7 +46,6 @@ Should result in this response:
       "name": "Famous Minnesotans",
       "slug": "minnesotans",
       "author_id": 15236,
-      "sort_order": "oldest_first",
       "count": 21
     },
     {
@@ -55,7 +53,6 @@ Should result in this response:
       "name": "Donors",
       "slug": "donors",
       "author_id": 15236,
-      "sort_order": "oldest_first",
       "count": 101
     }
   ]
@@ -156,7 +153,6 @@ Should result in this response:
     "name": "My List",
     "slug": "mylist",
     "author_id": 17736,
-    "sort_order": "street_address",
     "count": 0
   }
 }
@@ -211,7 +207,6 @@ results in:
   "name": "my list",
   "slug": "my-list",
   "author_id": 2,
-  "sort_order": "oldest_first",
   "count": 3
 }
 ```
@@ -248,7 +243,6 @@ results in:
   "name": "my list",
   "slug": "my-list",
   "author_id": 2,
-  "sort_order": "oldest_first",
   "count": 0
 }
 ```

--- a/doc/people_api.md
+++ b/doc/people_api.md
@@ -289,6 +289,26 @@ Resources
 * `state` - which state the election was held in (required for US elections),
 * `vote_method` - how the ballot was cast (required)
 
+Count Endpoint
+--------------
+
+The count endpoint provides a total count of all the people in the nation.
+
+```
+GET /api/v1/people/count
+```
+
+### Example
+
+```
+GET https://foobar.nationbuilder.com/api/v1/people/count
+```
+
+```json
+{
+  "people_count": 90013
+}
+```
 
 Index Endpoint
 --------------


### PR DESCRIPTION
Removes `sort_order` from lists and adds documentation for `people#count.`

@kaip @sethtrain 